### PR TITLE
Added support to launch webapp using tinyproxy.

### DIFF
--- a/src/agl/WebAppManagerServiceAGL.cpp
+++ b/src/agl/WebAppManagerServiceAGL.cpp
@@ -151,7 +151,10 @@ public:
           res.push_back(strdup(s.c_str()));
       }
 
-      WebAppManagerServiceAGL::instance()->setStartupApplication(std::string(res[0]), std::string(res[1]), atoi(res[2]));
+      WebAppManagerServiceAGL::instance()->setStartupApplication(
+        std::string(res[0]), std::string(res[1]), atoi(res[2]),
+        std::string(res[3]));
+
       WebAppManagerServiceAGL::instance()->triggerStartupApp();
       return 1;
     }
@@ -196,11 +199,15 @@ void WebAppManagerServiceAGL::launchOnHost(int argc, const char **argv)
     socket_->sendMsg(argc, argv);
 }
 
-void WebAppManagerServiceAGL::setStartupApplication(const std::string& startup_app_id, const std::string& startup_app_uri, int startup_app_surface_id)
+void WebAppManagerServiceAGL::setStartupApplication(
+    const std::string& startup_app_id,
+    const std::string& startup_app_uri, int startup_app_surface_id,
+    const std::string& startup_proxy_rules)
 {
     startup_app_id_ = startup_app_id;
     startup_app_uri_ = startup_app_uri;
     startup_app_surface_id_ = startup_app_surface_id;
+    startup_proxy_rules_ = startup_proxy_rules;
 }
 
 void *run_socket(void *socket) {
@@ -331,6 +338,10 @@ fprintf(stderr, "    url: %s\r\n", startup_app_uri_.c_str());
     std::string app_id = obj["id"].toString().toStdString();
     int errCode = 0;
     std::string errMsg;
+
+    if (!startup_proxy_rules_.empty())
+        WebAppManagerService::setProxyRules(startup_proxy_rules_);
+
     WebAppManagerService::onLaunch(appDesc, params, app_id, errCode, errMsg);
 }
 

--- a/src/agl/WebAppManagerServiceAGL.h
+++ b/src/agl/WebAppManagerServiceAGL.h
@@ -19,7 +19,10 @@ public:
     bool initializeAsHostClient();
 
     bool isHostServiceRunning();
-    void setStartupApplication(const std::string& startup_app_id, const std::string& startup_app_uri, int startup_app_surface_id);
+
+    void setStartupApplication(const std::string& startup_app_id,
+        const std::string& startup_app_uri, int startup_app_surface_id,
+        const std::string& startup_proxy_rules =  std::string());
 
     void launchOnHost(int argc, const char **argv);
 
@@ -48,6 +51,7 @@ private:
 
     std::string startup_app_id_;
     std::string startup_app_uri_;
+    std::string startup_proxy_rules_;
     int startup_app_surface_id_;
     OneShotTimer<WebAppManagerServiceAGL> startup_app_timer_;
 

--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -131,16 +131,20 @@ int SharedBrowserProcessWebAppLauncher::launch(const std::string& id, const std:
     return -1;
   }
 
-  tiny_proxy = std::make_unique<TinyProxy>();
-  int port = tiny_proxy->port();
-  std::string proxy_rules = "localhost:" + std::to_string(port);
-  WebAppManager::instance()->setProxyRules(proxy_rules.data());
+  tiny_proxy_ = std::make_unique<TinyProxy>();
+  int port = tiny_proxy_->port();
+  std::string proxy_rules = std::string("localhost");
+  proxy_rules.append(":");
+  proxy_rules.append(std::to_string(port));
+
   m_rid = (int)getpid();
   std::string m_rid_s = std::to_string(m_rid);
   std::vector<const char*> data;
   data.push_back(id.c_str());
   data.push_back(uri.c_str());
   data.push_back(m_rid_s.c_str());
+  data.push_back(proxy_rules.c_str());
+
   WebAppManagerServiceAGL::instance()->launchOnHost(data.size(), data.data());
   return m_rid;
 }

--- a/src/agl/WebRuntimeAGL.h
+++ b/src/agl/WebRuntimeAGL.h
@@ -2,6 +2,7 @@
 #define WEBRUNTIME_AGL_H
 
 #include <map>
+#include <memory>
 #include <signal.h>
 #include <string>
 #include <vector>
@@ -40,10 +41,22 @@ public:
   std::vector<pid_t> m_pid_v;
 };
 
+class TinyProxy {
+ public:
+  int port() { return port_; }
+  void setPort(int port) { port_ = port; }
+
+  TinyProxy();
+private:
+  int port_;
+};
+
 class SharedBrowserProcessWebAppLauncher : public Launcher {
 public:
   int launch(const std::string& id, const std::string& uri) override;
   int loop(int argc, const char** argv, volatile sig_atomic_t& e_flag) override;
+private:
+  std::unique_ptr<TinyProxy> tiny_proxy;
 };
 
 class SingleBrowserProcessWebAppLauncher : public Launcher {

--- a/src/agl/WebRuntimeAGL.h
+++ b/src/agl/WebRuntimeAGL.h
@@ -56,7 +56,7 @@ public:
   int launch(const std::string& id, const std::string& uri) override;
   int loop(int argc, const char** argv, volatile sig_atomic_t& e_flag) override;
 private:
-  std::unique_ptr<TinyProxy> tiny_proxy;
+  std::unique_ptr<TinyProxy> tiny_proxy_;
 };
 
 class SingleBrowserProcessWebAppLauncher : public Launcher {

--- a/src/core/WebAppManager.cpp
+++ b/src/core/WebAppManager.cpp
@@ -1057,3 +1057,8 @@ int WebAppManager::maskForBrowsingDataType(const char* type)
 {
     return m_webProcessManager->maskForBrowsingDataType(type);
 }
+
+void WebAppManager::setProxyRules(const char* proxyRules)
+{
+    m_webProcessManager->setProxyRules(proxyRules); 
+}

--- a/src/core/WebAppManager.cpp
+++ b/src/core/WebAppManager.cpp
@@ -1058,7 +1058,8 @@ int WebAppManager::maskForBrowsingDataType(const char* type)
     return m_webProcessManager->maskForBrowsingDataType(type);
 }
 
-void WebAppManager::setProxyRules(const char* proxyRules)
+void WebAppManager::setProxyRules(const std::string& proxy_rules)
 {
-    m_webProcessManager->setProxyRules(proxyRules); 
+    if (m_webProcessManager)
+        m_webProcessManager->setProxyRules(proxy_rules);
 }

--- a/src/core/WebAppManager.h
+++ b/src/core/WebAppManager.h
@@ -160,7 +160,7 @@ public:
 
     void clearBrowsingData(const int removeBrowsingDataMask);
     int maskForBrowsingDataType(const char* type);
-    void setProxyRules(const char* proxyRules);
+    void setProxyRules(const std::string& proxy_rules);
 
 protected:
 private:

--- a/src/core/WebAppManager.h
+++ b/src/core/WebAppManager.h
@@ -160,6 +160,7 @@ public:
 
     void clearBrowsingData(const int removeBrowsingDataMask);
     int maskForBrowsingDataType(const char* type);
+    void setProxyRules(const char* proxyRules);
 
 protected:
 private:

--- a/src/core/WebAppManagerService.cpp
+++ b/src/core/WebAppManagerService.cpp
@@ -225,3 +225,8 @@ int WebAppManagerService::maskForBrowsingDataType(const char* type)
 {
     return WebAppManager::instance()->maskForBrowsingDataType(type);
 }
+
+void WebAppManagerService::setProxyRules(const std::string& proxy_rules)
+{
+    WebAppManager::instance()->setProxyRules(proxy_rules);
+}

--- a/src/core/WebAppManagerService.h
+++ b/src/core/WebAppManagerService.h
@@ -82,6 +82,7 @@ protected:
     QJsonObject closeByInstanceId(QString instanceId);
     int maskForBrowsingDataType(const char* type);
     void onClearBrowsingData(const int removeBrowsingDataMask);
+    void setProxyRules(const std::string& proxy_rules);
 
     WebAppBase* getContainerApp();
 #ifndef PRELOADMANAGER_ENABLED

--- a/src/core/WebProcessManager.h
+++ b/src/core/WebProcessManager.h
@@ -49,7 +49,7 @@ public:
     virtual uint32_t getInitialWebViewProxyID() const = 0;
     virtual void clearBrowsingData(const int removeBrowsingDataMask) = 0;
     virtual int maskForBrowsingDataType(const char* type) = 0;
-    virtual void setProxyRules(const char* proxyRules) = 0;
+    virtual void setProxyRules(const std::string& proxy_rules) = 0;
 protected:
     std::list<const WebAppBase*> runningApps();
     std::list<const WebAppBase*> runningApps(uint32_t pid);

--- a/src/core/WebProcessManager.h
+++ b/src/core/WebProcessManager.h
@@ -49,7 +49,7 @@ public:
     virtual uint32_t getInitialWebViewProxyID() const = 0;
     virtual void clearBrowsingData(const int removeBrowsingDataMask) = 0;
     virtual int maskForBrowsingDataType(const char* type) = 0;
-
+    virtual void setProxyRules(const char* proxyRules) = 0;
 protected:
     std::list<const WebAppBase*> runningApps();
     std::list<const WebAppBase*> runningApps(uint32_t pid);

--- a/src/platform/webengine/BlinkWebProcessManager.cpp
+++ b/src/platform/webengine/BlinkWebProcessManager.cpp
@@ -120,6 +120,6 @@ int BlinkWebProcessManager::maskForBrowsingDataType(const char* type)
     return BlinkWebViewProfileHelper::maskForBrowsingDataType(type);
 }
 
-void BlinkWebProcessManager::setProxyRules(const char* proxyRules) {
-    return BlinkWebViewProfileHelper::setProxyRules(proxyRules);
+void BlinkWebProcessManager::setProxyRules(const std::string& proxy_rules) {
+    BlinkWebViewProfileHelper::setProxyRules(proxy_rules);
 }

--- a/src/platform/webengine/BlinkWebProcessManager.cpp
+++ b/src/platform/webengine/BlinkWebProcessManager.cpp
@@ -119,3 +119,7 @@ int BlinkWebProcessManager::maskForBrowsingDataType(const char* type)
 {
     return BlinkWebViewProfileHelper::maskForBrowsingDataType(type);
 }
+
+void BlinkWebProcessManager::setProxyRules(const char* proxyRules) {
+    return BlinkWebViewProfileHelper::setProxyRules(proxyRules);
+}

--- a/src/platform/webengine/BlinkWebProcessManager.h
+++ b/src/platform/webengine/BlinkWebProcessManager.h
@@ -31,6 +31,7 @@ public:
     uint32_t getInitialWebViewProxyID() const override;
     void clearBrowsingData(const int removeBrowsingDataMask) override;
     int maskForBrowsingDataType(const char* type) override;
+    void setProxyRules(const char* proxyRules) override;
 };
 
 #endif /* BLINKEBPROCESSMANAGER_H */

--- a/src/platform/webengine/BlinkWebProcessManager.h
+++ b/src/platform/webengine/BlinkWebProcessManager.h
@@ -31,7 +31,7 @@ public:
     uint32_t getInitialWebViewProxyID() const override;
     void clearBrowsingData(const int removeBrowsingDataMask) override;
     int maskForBrowsingDataType(const char* type) override;
-    void setProxyRules(const char* proxyRules) override;
+    void setProxyRules(const std::string& proxy_rules) override;
 };
 
 #endif /* BLINKEBPROCESSMANAGER_H */

--- a/src/platform/webengine/BlinkWebViewProfileHelper.cpp
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.cpp
@@ -64,3 +64,7 @@ int BlinkWebViewProfileHelper::maskForBrowsingDataType(const char* type) {
 
     return 0;
 }
+
+void BlinkWebViewProfileHelper::setProxyRules(const char* proxyRules) {
+    webos::WebViewProfile::GetDefaultProfile()->SetProxyRules(proxyRules);
+}

--- a/src/platform/webengine/BlinkWebViewProfileHelper.cpp
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.cpp
@@ -17,7 +17,8 @@
 
 #include "BlinkWebViewProfileHelper.h"
 #include "webos/webview_profile.h"
-#include <string.h>
+
+#include <cstring>
 
 void BlinkWebViewProfileHelper::clearBrowsingData(const int removeBrowsingDataMask,
         webos::WebViewProfile *profile)
@@ -65,6 +66,6 @@ int BlinkWebViewProfileHelper::maskForBrowsingDataType(const char* type) {
     return 0;
 }
 
-void BlinkWebViewProfileHelper::setProxyRules(const char* proxyRules) {
-    webos::WebViewProfile::GetDefaultProfile()->SetProxyRules(proxyRules);
+void BlinkWebViewProfileHelper::setProxyRules(const std::string& proxy_rules) {
+    webos::WebViewProfile::GetDefaultProfile()->SetProxyRules(proxy_rules);
 }

--- a/src/platform/webengine/BlinkWebViewProfileHelper.h
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.h
@@ -17,6 +17,8 @@
 #ifndef BLINK_WEB_VIEW_PROFILE_HELPER_H_
 #define BLINK_WEB_VIEW_PROFILE_HELPER_H_
 
+#include <string>
+
 namespace webos {
 class WebViewProfile;
 }
@@ -45,7 +47,7 @@ public:
         webos::WebViewProfile* profile = nullptr);
     static void clearDefaultBrowsingData(const int removeBrowsingDataMask);
     static int maskForBrowsingDataType(const char* key);
-    static void setProxyRules(const char* proxyRules);
+    static void setProxyRules(const std::string& proxy_rules);
 };
 
 #endif // BLINK_WEB_VIEW_PROFILE_HELPER_H_

--- a/src/platform/webengine/BlinkWebViewProfileHelper.h
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.h
@@ -45,6 +45,7 @@ public:
         webos::WebViewProfile* profile = nullptr);
     static void clearDefaultBrowsingData(const int removeBrowsingDataMask);
     static int maskForBrowsingDataType(const char* key);
+    static void setProxyRules(const char* proxyRules);
 };
 
 #endif // BLINK_WEB_VIEW_PROFILE_HELPER_H_


### PR DESCRIPTION
Implement proxy configuration handling for shared browser process WebAppLauncher to manage one proxy process per web app instance.

Before launching a webapp through shared browser process model, current implementation launch tinyproxy using -p <port_number> command line option and forward same port to WebViewProfile to configure proxy service

TBR = @jdapena