### PR TITLE
Fix std filesystem API linker errors

### DIFF
--- a/wam.pri
+++ b/wam.pri
@@ -24,7 +24,7 @@ CONFIG += no_keywords
 SOURCES += \
         Main.cpp
 
-LIBS += -lWebAppMgr -lWebAppMgrCore
+LIBS += -lWebAppMgr -lWebAppMgrCore -lstdc++fs
 
 TARGET = WebAppMgr
 


### PR DESCRIPTION
After 123eb5522e7d, std Filesystem API is being used in
WebApplicationFactoryManager replacing previous Qt-based
implementation. With the libstdc++ version currently being
used is necessary explicitly link against libstdc++fs library[1],
otherwise linker fails with some "undefined reference" errors,
when targeting Renesas R-car M3 board.

[1] https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dynamic_or_shared.html#manual.intro.using.linkage.experimental

[SPEC-1871] Qt-less WAM - https://jira.automotivelinux.org/browse/SPEC-1871

Signed-off-by: Nick Diego Yamane <nickd@igalia.com>