### PR TITLE
Drop config.xml and use web os appinfo.json 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,6 @@ if(OS_WEBOS)
 elseif(OS_AGL)
     set(DISABLE_PMLOG TRUE)
     add_compile_definitions(OS_AGL)
-    pkg_search_module(LIBXML2 REQUIRED libxml-2.0)
 endif()
 
 if(DISABLE_PMLOG)

--- a/src/agl/web_app_manager_service_agl.cc
+++ b/src/agl/web_app_manager_service_agl.cc
@@ -264,7 +264,7 @@ void WebAppManagerServiceAGL::SetStartupApplication(
   surface_role_ = surface_role;
   panel_type_ = panel_type;
 
-  width_ = width_;
+  width_ = width;
   height_ = height;
 }
 
@@ -340,21 +340,6 @@ void WebAppManagerServiceAGL::LaunchStartupAppFromJsonConfig() {
   if (!parseFromStream(builder, ifs, &root, &errs)) {
     LOG_DEBUG("Failed to parse %s configuration file", configfile.c_str());
   }
-
-  root["folderPath"] = startup_app_uri_.c_str();
-
-  std::string width = root["surface"].get("width", std::string("0")).asString();
-  std::string height =
-      root["surface"].get("height", std::string("0")).asString();
-
-  if (width != std::string("0"))
-    width_ = atoi(width.c_str());
-  else
-    width_ = 0;
-  if (height != std::string("0"))
-    height_ = atoi(height.c_str());
-  else
-    height_ = 0;
 
   if (width_)
     root["widthOverride"] = width_;

--- a/src/agl/web_app_manager_service_agl.h
+++ b/src/agl/web_app_manager_service_agl.h
@@ -75,6 +75,7 @@ class WebAppManagerServiceAGL : public WebAppManagerService {
   WebAppManagerServiceAGL();
 
   void LaunchStartupAppFromConfig();
+  void LaunchStartupAppFromJsonConfig();
   void LaunchStartupAppFromURL();
 
   void OnActivateEvent();

--- a/src/agl/web_runtime_agl.h
+++ b/src/agl/web_runtime_agl.h
@@ -106,7 +106,7 @@ class WebAppLauncherRuntime : public WebRuntime {
   bool Init(Args* args);
   bool InitWM();
   bool InitHS();
-  int ParseConfig(const char* file);
+  bool ParseJsonConfig(const char* file);
   void SetupSignals();
 
   std::string id_;

--- a/src/agl/web_runtime_agl.h
+++ b/src/agl/web_runtime_agl.h
@@ -24,6 +24,43 @@
 #include "agl_shell_types.h"
 #include "web_runtime.h"
 
+class Args {
+ public:
+  enum flags {
+    FLAG_NONE = 0,
+    FLAG_APP_TYPE = 1 << 0,
+    FLAG_ACTIVATE_APP = 1 << 1,
+    FLAG_HTTP_LINK = 1 << 2,
+    FLAG_APP_ID = 1 << 3,
+    FLAG_APP_DIR = 1 << 4,
+  };
+
+  static Args* Instance() {
+    static Args* args = new Args();
+    return args;
+  }
+  void parse_args(int argc, const char** argv);
+
+  inline void set_flag(unsigned int flag) { flags |= flag; }
+
+  inline void clear_flag(unsigned int flag) { flags &= ~flag; }
+
+  inline bool is_set_flag(unsigned int flag) { return (flags & flag) == flag; }
+  void clear_cmdline(void);
+
+  std::string type_;
+  std::string activate_app_;
+  std::string http_link_;
+  std::string app_id_;
+  std::string app_dir_;
+
+ private:
+  uint32_t flags = FLAG_NONE;
+  void copy_cmdline(int argc, const char** argv);
+  char** new_argv;
+  int new_argc;
+};
+
 class Launcher {
  public:
   virtual int Launch(const std::string& id,
@@ -66,7 +103,7 @@ class WebAppLauncherRuntime : public WebRuntime {
   int Run(int argc, const char** argv) override;
 
  private:
-  bool Init();
+  bool Init(Args* args);
   bool InitWM();
   bool InitHS();
   int ParseConfig(const char* file);

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -98,8 +98,6 @@ elseif(OS_AGL)
         ${WAM_ROOT_SOURCE_DIR}/agl/web_app_manager_service_agl.h
         ${WAM_ROOT_SOURCE_DIR}/agl/web_runtime_agl.h
     )
-    LIST(APPEND WAM_LIB_INCLUDE_DIRS ${LIBXML2_INCLUDE_DIRS})
-    LIST(APPEND WAM_LIB_LIBS ${LIBXML2_LDFLAGS})
 endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADERS} ${SOURCES})


### PR DESCRIPTION
This series drops support for reading XMLs configuration files and instead relies on using json files, similar to those defined by webos in https://www.webosose.org/docs/guides/development/configuration-files/appinfo-json/.

This series includes the changes I've added previous in https://github.com/Igalia/webosose-wam/pull/13 and depends on it.

And appinfo.json for homescreen now looks like the following:

```
{
    "id"                  : "homescreen",
    "title"               : "Homescreen",
    "main"                : "index.html",
    "icon"                : "icon.svg",
    "type"                : "web",
    "vendor"              : "Igalia, S.L",
    "version"             : "1.0",
    "transparent"         : false,
    "appDescription"      : "HTML5 Homescreen demo",
    "license"             : "APL 2.0",
    "author"              : "Igalia, S.L.",
    "folderPath"          : "/usr/lib/wam_apps/html5-homescreen/",
    "surface"             : { "role" : "panel", "panel_edge" : "left", "width" : "218" },
    "extensions"          : [ "agl_appservice" ]
}
```
